### PR TITLE
Adding option to specify ONOS_ADDRESS

### DIFF
--- a/onos-files/install-onos-applications.sh
+++ b/onos-files/install-onos-applications.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ONOS_ADDRESS=${ONOS_ADDRESS:-127.0.0.1}
+
 SADIS_VER=${SADIS_VER:-3.1.0}
 OLT_VER=${OLT_VER:-3.0.1}
 AAA_VER=${AAA_VER:-1.9.0}
@@ -41,6 +43,8 @@ else
     ONOS_SSH_PORT=${ONOS_SSH_PORT:-8101}
 fi
 
+echo "Target ONOS is ${ONOS_ADDRESS}:${ONOS_API_PORT}"
+
 mkdir -p onos-files/onos-apps
 echo "Downloading ONOS applications"
 curl --fail -sSL https://repo.maven.apache.org/maven2/org/opencord/sadis-app/$SADIS_VER/sadis-app-$SADIS_VER.oar -o ./onos-files/onos-apps/sadis-app-$SADIS_VER.oar
@@ -48,11 +52,11 @@ curl --fail -sSL https://repo.maven.apache.org/maven2/org/opencord/$AAA_NAME/$AA
 curl --fail -sSL https://repo.maven.apache.org/maven2/org/opencord/olt-app/$OLT_VER/olt-app-$OLT_VER.oar -o ./onos-files/onos-apps/olt-app-$OLT_VER.oar
 curl --fail -sSL https://repo.maven.apache.org/maven2/org/opencord/$DHCP_NAME/$DHCP_VER/$DHCP_NAME-$DHCP_VER.oar -o ./onos-files/onos-apps/dhcpl2relay-app-$DHCP_VER.oar
 
-until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/octet-stream http://127.0.0.1:$ONOS_API_PORT/onos/v1/applications?activate=true --data-binary @./onos-files/onos-apps/sadis-app-$SADIS_VER.oar 2>/dev/null | tail -1) -eq 409; do echo "Installing 'SADIS' ONOS application ..."; sleep 1; done
-until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/octet-stream http://127.0.0.1:$ONOS_API_PORT/onos/v1/applications?activate=true --data-binary @./onos-files/onos-apps/olt-app-$OLT_VER.oar 2>/dev/null | tail -1) -eq 409; do echo "Installing 'OLT' ONOS application ..."; sleep 1; done
-until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/octet-stream http://127.0.0.1:$ONOS_API_PORT/onos/v1/applications?activate=true --data-binary @./onos-files/onos-apps/aaa-app-$AAA_VER.oar 2>/dev/null | tail -1) -eq 409; do echo "Installing 'AAA' ONOS application ..."; sleep 1; done
-until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/octet-stream http://127.0.0.1:$ONOS_API_PORT/onos/v1/applications?activate=true --data-binary @./onos-files/onos-apps/dhcpl2relay-app-$DHCP_VER.oar 2>/dev/null | tail -1) -eq 409; do echo "Installing 'DHCP L2 Relay' ONOS application ..."; sleep 1; done
-until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/json http://127.0.0.1:$ONOS_API_PORT/onos/v1/network/configuration --data @onos-files/olt-onos-netcfg.json 2>/dev/null | tail -1) -eq 200; do echo "Configuring VOLTHA ONOS ..."; sleep 1; done
-until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/json http://127.0.0.1:$ONOS_API_PORT/onos/v1/configuration/org.opencord.olt.impl.Olt --data @onos-files/olt-onos-olt-settings.json 2>/dev/null | tail -1) -eq 200; do echo "Enabling VOLTHA ONOS DHCP provisioning..."; sleep 1; done
-until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/json http://127.0.0.1:$ONOS_API_PORT/onos/v1/configuration/org.onosproject.net.flow.impl.FlowRuleManager --data @onos-files/olt-onos-enableExtraneousRules.json 2>/dev/null | tail -1) -eq 200; do echo "Enabling extraneous rules for ONOS..."; sleep 1; done
-until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/json "http://127.0.0.1:$ONOS_API_PORT/onos/v1/flows/of:0000000000000001?appId=env.voltha" --data @onos-files/dhcp-to-controller-flow.json 2>/dev/null | tail -1) -eq 201; do echo "Establishing DHCP packet-in flow ..."; sleep 1; done
+until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/octet-stream http://$ONOS_ADDRESS:$ONOS_API_PORT/onos/v1/applications?activate=true --data-binary @./onos-files/onos-apps/sadis-app-$SADIS_VER.oar 2>/dev/null | tail -1) -eq 409; do echo "Installing 'SADIS' ONOS application (v${SADIS_VER})..."; sleep 1; done
+until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/octet-stream http://$ONOS_ADDRESS:$ONOS_API_PORT/onos/v1/applications?activate=true --data-binary @./onos-files/onos-apps/olt-app-$OLT_VER.oar 2>/dev/null | tail -1) -eq 409; do echo "Installing 'OLT' ONOS application (v${OLT_VER})..."; sleep 1; done
+until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/octet-stream http://$ONOS_ADDRESS:$ONOS_API_PORT/onos/v1/applications?activate=true --data-binary @./onos-files/onos-apps/aaa-app-$AAA_VER.oar 2>/dev/null | tail -1) -eq 409; do echo "Installing 'AAA' ONOS application (v${AAA_VER})..."; sleep 1; done
+until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/octet-stream http://$ONOS_ADDRESS:$ONOS_API_PORT/onos/v1/applications?activate=true --data-binary @./onos-files/onos-apps/dhcpl2relay-app-$DHCP_VER.oar 2>/dev/null | tail -1) -eq 409; do echo "Installing 'DHCP L2 Relay' ONOS application (v${DHCP_VER})..."; sleep 1; done
+until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/json http://$ONOS_ADDRESS:$ONOS_API_PORT/onos/v1/network/configuration --data @onos-files/olt-onos-netcfg.json 2>/dev/null | tail -1) -eq 200; do echo "Configuring VOLTHA ONOS ..."; sleep 1; done
+until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/json http://$ONOS_ADDRESS:$ONOS_API_PORT/onos/v1/configuration/org.opencord.olt.impl.Olt --data @onos-files/olt-onos-olt-settings.json 2>/dev/null | tail -1) -eq 200; do echo "Enabling VOLTHA ONOS DHCP provisioning..."; sleep 1; done
+until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/json http://$ONOS_ADDRESS:$ONOS_API_PORT/onos/v1/configuration/org.onosproject.net.flow.impl.FlowRuleManager --data @onos-files/olt-onos-enableExtraneousRules.json 2>/dev/null | tail -1) -eq 200; do echo "Enabling extraneous rules for ONOS..."; sleep 1; done
+until test $(curl -w '\n%{http_code}' --fail -sSL --user karaf:karaf -X POST -H Content-Type:application/json "http://$ONOS_ADDRESS:$ONOS_API_PORT/onos/v1/flows/of:0000000000000001?appId=env.voltha" --data @onos-files/dhcp-to-controller-flow.json 2>/dev/null | tail -1) -eq 201; do echo "Establishing DHCP packet-in flow ..."; sleep 1; done


### PR DESCRIPTION
Useful in order to use this script against a remote installation, for example:

```
$ ./onos-files/install-onos-applications.sh
Target ONOS is 127.0.0.1:8181

$ export ONOS_API_PORT=30120
$ export ONOS_SSH_PORT=30115
$ export ONOS_ADDRESS=10.90.0.101
$ ./onos-files/install-onos-applications.sh
Target ONOS is 10.90.0.101:30120
Downloading ONOS applications
Installing 'SADIS' ONOS application (v2.2.0)...
Installing 'OLT' ONOS application (v2.1.0)...
Installing 'AAA' ONOS application (v1.8.0)...
Installing 'DHCP L2 Relay' ONOS application (v1.5.0)...
```
