### PR TITLE
Improve Helm install failure handling

### DIFF
--- a/voltha
+++ b/voltha
@@ -695,7 +695,9 @@ helm_install() {
         sspin $INDENT
         COUNT=$(expr $COUNT - 1)
         if [ $COUNT -eq 0 ]; then
+            (set -x; helm delete --purge $INAME >>$LOG 2>&1) >>$LOG 2>&1
             (set -x; helm install -f $NAME-values.yaml $CHART_ARGS --set defaults.log_level=$VOLTHA_LOG_LEVEL --namespace $NAMESPACE --name $INAME $CHART_VERSION $EXTRA_HELM_FLAGS $CHART >>$LOG 2>&1) >>$LOG 2>&1
+            SUCCESS=$?
             COUNT=$(expr 300 / 15)
         fi
         sleep .15


### PR DESCRIPTION
Need to update SUCCESS to get out of the loop.  Also purge the failed chart before we try to reinstall.