### PR TITLE
Configuring Sadis by default if the WITH_BBSIM flag is set to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Please check the `releases` folder to see the available ones.
 | `WITH_RADIUS`                   | no                           | Should `freeradius` service be deployed?                                            |
 | `WITH_TIMINGS`                  | no                           | Outputs duration of various steps of the install                                    |
 | `WITH_CHAOS`                    | no                           | Starts kube-monkey to introduce chaos                                               |
-| `CONFIG_SADIS`                  | no                           | Configure SADIS entries into ONOS, if WITH_ONOS set (see SADIS Configuration        |    
 | `INSTALL_ONOS_APPS`             | no                           | Replaces/installs ONOS OAR files in onos-files/onos-apps                            |
 | `INSTALL_KUBECTL`               | yes                          | Should a copy of `kubectl` be installed locally?                                    |
 | `INSTALL_HELM`                  | yes                          | Should a copy of `helm` be installed locallly?                                      |

--- a/onos-files/onos-sadis-sample.json
+++ b/onos-files/onos-sadis-sample.json
@@ -1,82 +1,22 @@
 {
   "sadis": {
     "integration": {
+      "url":"http://bbsim.voltha.svc:50074/subscribers/%s",
       "cache": {
-        "enabled": false,
-        "maxsize": 50,
-        "ttl": "PT0m"
+        "enabled":true,
+        "maxsize":50,
+        "ttl":"PT1m"
       }
-    },
-    "entries": [
-      {
-        "id": "BBSIM_OLT_0",
-        "hardwareIdentifier": "0f:f1:ce:c0:ff:ee",
-        "nasId": "BBSIMOLT000",
-        "uplinkPort": 1048576
-      },
-      {
-        "id": "BBSM00000001-1",
-        "cTag": 900,
-        "sTag": 900,
-        "nasPortId": "BBSM00000001-1",
-        "circuitId": "BBSM00000001-1",
-        "remoteId": "BBSIMOLT000",
-        "technologyProfileId": 64,
-        "upstreamBandwidthProfile": "Default",
-        "downstreamBandwidthProfile": "Default"
-      },
-      {
-        "id": "BBSM00000002-1",
-        "cTag": 901,
-        "sTag": 900,
-        "nasPortId": "BBSM00000002-1",
-        "circuitId": "BBSM00000002-1",
-        "remoteId": "BBSIMOLT000",
-        "technologyProfileId": 64,
-        "upstreamBandwidthProfile": "Default",
-        "downstreamBandwidthProfile": "Default"
-      },
-      {
-        "id": "BBSM00000101-1",
-        "cTag": 902,
-        "sTag": 900,
-        "nasPortId": "BBSM00000101-1",
-        "circuitId": "BBSM00000101-1",
-        "remoteId": "BBSIMOLT000",
-        "technologyProfileId": 64,
-        "upstreamBandwidthProfile": "Default",
-        "downstreamBandwidthProfile": "Default"
-      },
-      {
-        "id": "BBSM00000102-1",
-        "cTag": 903,
-        "sTag": 900,
-        "nasPortId": "BBSM00000102-1",
-        "circuitId": "BBSM00000102-1",
-        "remoteId": "BBSIMOLT000",
-        "technologyProfileId": 64,
-        "upstreamBandwidthProfile": "Default",
-        "downstreamBandwidthProfile": "Default"
-      }
-    ]
+    }
   },
   "bandwidthprofile": {
     "integration": {
+      "url":"http://bbsim.voltha.svc:50074/bandwidthprofiles/%s",
       "cache": {
-        "enabled": true,
-        "maxsize": 40,
-        "ttl": "PT1m"
+        "enabled":true,
+        "maxsize":40,
+        "ttl":"PT1m"
       }
-    },
-    "entries": [
-      {
-        "id": "Default",
-        "cir": 1000000,
-        "cbs": 1001,
-        "eir": 1002,
-        "ebs": 1003,
-        "air": 1004
-      }
-    ]
+    }
   }
 }

--- a/voltha
+++ b/voltha
@@ -76,7 +76,6 @@ WITH_ADAPTERS=${WITH_ADAPTERS:-yes}
 WITH_SIM_ADAPTERS=${WITH_SIM_ADAPTERS:-yes}
 WITH_OPEN_ADAPTERS=${WITH_OPEN_ADAPTERS:-yes}
 ONLY_ONE=${ONLY_ONE:-yes}
-CONFIG_SADIS=${CONFIG_SADIS:-no}
 INSTALL_ONOS_APPS=${INSTALL_ONOS_APPS:-no}
 JUST_K8S=${JUST_K8S:-no}
 DEPLOY_K8S=${DEPLOY_K8S:-yes}
@@ -138,7 +137,6 @@ ALL_YES_NO="\
     WITH_ADAPTERS \
     WITH_SIM_ADAPTERS \
     WITH_OPEN_ADAPTERS \
-    CONFIG_SADIS \
     JUST_K8S \
     DEPLOY_K8S \
     INSTALL_ONOS_APPS \
@@ -1090,7 +1088,7 @@ if [ $WITH_ONOS == "yes" ]; then
     push_onos_config "Enabling extraneous rules for ONOS" "configuration/org.onosproject.net.flow.impl.FlowRuleManager" "onos-files/olt-onos-enableExtraneousRules.json"
     if [ -f onos-files/onos-sadis.json ]; then
         push_onos_config "[optional] Push ONOS SADIS Configuration" "network/configuration/apps/org.opencord.sadis" "onos-files/onos-sadis.json"
-    elif [ "$CONFIG_SADIS" == "yes" ]; then
+    elif [ "$WITH_BBSIM" == "yes" ]; then
         SADIS_CFG=onos-files/onos-sadis-sample.json
         check_onos_app_active org.opencord.sadis
         push_onos_config "[optional] Push ONOS SADIS Configuration" "network/configuration/apps/org.opencord.sadis" "$SADIS_CFG"


### PR DESCRIPTION
The reasoning behind this PR is that the Sadis config in this repo only works for BBSim,
thus add it by default to ONOS is BBSim is installed, don't push it otherwise.