### PR TITLE
Adding support to install prometheus and track ETCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Please check the `releases` folder to see the available ones.
 | `WITH_RADIUS`                   | no                           | Should `freeradius` service be deployed?                                            |
 | `WITH_TIMINGS`                  | no                           | Outputs duration of various steps of the install                                    |
 | `WITH_CHAOS`                    | no                           | Starts kube-monkey to introduce chaos                                               |
+| `WITH_MONITORING`               | no                           | Starts prometheus and grafana to monitor components usage                           |
 | `CONFIG_SADIS`                  | no                           | Configure SADIS entries into ONOS, if WITH_ONOS set (see SADIS Configuration        |    
 | `INSTALL_ONOS_APPS`             | no                           | Replaces/installs ONOS OAR files in onos-files/onos-apps                            |
 | `INSTALL_KUBECTL`               | yes                          | Should a copy of `kubectl` be installed locally?                                    |

--- a/minimal-values.yaml
+++ b/minimal-values.yaml
@@ -105,6 +105,65 @@ onus_per_pon_port: 1
 auth: true
 dhcp: true
 
+# Customization for monitoring
+kpi_exporter:
+  enabled: false
+  kpi_broker: voltha-kafka.voltha.svc:9092
+grafana:
+  # dashboards:
+  #   default:
+  #     ETCD:
+  #       gnetId: 10323
+  #       revision: 1
+  #       datasource: Prometheus
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          url: http://monitoring-prometheus-server
+          access: proxy
+          isDefault: true
+
+dashboards:
+  k8s: true
+  nodeExporter: true
+  xos: false
+  onos: false
+  aaa: false
+  voltha: false
+  voltha2: true
+
+prometheus:
+  extraScrapeConfigs: |
+    - job_name: 'kafka'
+      metrics_path: /metrics
+      scrape_interval: 10s
+      static_configs:
+       - targets:
+         - voltha-kafka-exporter.voltha.svc:9308
+    - job_name: 'etcd'
+      metrics_path: /metrics
+      scrape_interval: 10s
+      static_configs:
+        - targets:
+            - voltha-etcd-cluster.voltha.svc:2379
+    - job_name: 'node-exporter'
+      metrics_path: /metrics
+      scrape_interval: 30s
+      static_configs:
+        - targets:
+          - monitoring-prometheus-node-exporter:9100
+
+# Expose kafka prometheus port
+kafka:
+  prometheus:
+    jmx:
+      enabled: true
+    kafka:
+      enabled: true
+
 # SHOCK THE MONKEY OR LET LOSE THE DOGS OF WAR
 # The VOLTHA charts have support for adding extra labels to deployments and
 # pods. These extra labels can be used to integrate with other utilities

--- a/voltha
+++ b/voltha
@@ -69,6 +69,7 @@ TYPE=${TYPE:-minimal}
 NAME=${NAME:-$TYPE}
 WITH_TIMINGS=${WITH_TIMINGS:-no}
 WITH_BBSIM=${WITH_BBSIM:-no}
+WITH_MONITORING=${WITH_MONITORING:-no}
 WITH_RADIUS=${WITH_RADIUS:-no}
 WITH_ONOS=${WITH_ONOS:-yes}
 WITH_CHAOS=${WITH_CHAOS:-no}
@@ -96,6 +97,8 @@ VOLTHA_ADAPTER_OPEN_OLT_CHART_VERSION=${VOLTHA_ADAPTER_OPEN_OLT_CHART_VERSION:-l
 VOLTHA_ADAPTER_OPEN_ONU_CHART=${VOLTHA_ADAPTER_OPEN_ONU_CHART:-onf/voltha-adapter-openonu}
 VOLTHA_ADAPTER_OPEN_ONU_CHART_VERSION=${VOLTHA_ADAPTER_OPEN_ONU_CHART_VERSION:-latest}
 ONOS_CHART_VERSION=${ONOS_CHART_VERSION:-latest}
+MONITORING_CHART=${MONITORING_CHART:-onf/nem-monitoring}
+MONITORING_CHART_VERSION=${MONITORING_CHART_VERSION:-latest}
 EXTRA_HELM_INSTALL_ARGS=
 
 HAVE_GO=$(which go >/dev/null 2>&1 && echo "yes" || echo "no")
@@ -132,6 +135,7 @@ function verify_yes_no() {
 ALL_YES_NO="\
     WITH_TIMINGS \
     WITH_BBSIM \
+    WITH_MONITORING \
     WITH_RADIUS \
     WITH_ONOS \
     WITH_CHAOS \
@@ -511,7 +515,7 @@ port_forward() {
     local TO_PORT=$4
     local TAG=$SVC-$NAME
 
-    (set -x; _TAG=$TAG bash -c "while true; do kubectl port-forward -n $NS service/$SVC $FROM_PORT:$TO_PORT; done" >>$LOG 2>&1 &) >>$LOG 2>&1
+    (set -x; _TAG=$TAG bash -c "while true; do kubectl port-forward --address 0.0.0.0 -n $NS service/$SVC $FROM_PORT:$TO_PORT; done" >>$LOG 2>&1 &) >>$LOG 2>&1
 }
 
 kill_port_forward() {
@@ -560,7 +564,7 @@ if [ "$1" == "down" ]; then
         fi
     else
         EXISTS=$(helm list -q)
-        EXPECT="etcd-operator onos open-olt open-onu sim voltha bbsim radius"
+        EXPECT="etcd-operator onos open-olt open-onu sim voltha bbsim radius monitoring"
         bspin "Remove Helm Deployments"
         for i in $EXISTS; do
             if [ $(echo $EXPECT | grep -c $i) -eq 1 ]; then
@@ -1164,6 +1168,35 @@ if [ $WITH_BBSIM == "yes" ]; then
     if [ "$WITH_TIMINGS" == "yes" ]; then
         printtime $(expr $(date +%s) - $STIME)
     fi
+fi
+
+if [ $WITH_MONITORING == "yes" ]; then
+  STIME=$(date +%s)
+  echo -e "Verify MONITORING $PLUG"
+  bspin - "Verify MONITORING Installed"
+  if [ $(helm list --deployed --short --namespace default "^monitoring\$" | wc -l) -ne 1 ]; then
+      espin - $NOT_VERIFIED
+      helm_install - default monitoring $MONITORING_CHART $MONITORING_CHART_VERSION "Install MONITORING"
+  else
+      espin - $VERIFIED
+  fi
+  wait_for_pods - "default" 7 "includes" -1 "Waiting for MONITORING to start" "monitoring-.*"
+
+  bspin - "Forward prometheus UI port $FORWARD"
+  kill_port_forward monitoring-prometheus-server
+  port_forward default monitoring-prometheus-server 31301 80
+  espin - $VERIFIED
+  bspin - "Forward grafana UI port $FORWARD"
+  kill_port_forward monitoring-grafana
+  port_forward default monitoring-grafana 31300 80
+  espin - $VERIFIED
+
+  # this is required to expose the kafka metrics to prometheus
+  kubectl expose -n voltha deployment voltha-kafka-exporter
+
+  if [ "$WITH_TIMINGS" == "yes" ]; then
+      printtime $(expr $(date +%s) - $STIME)
+  fi
 fi
 
 if [ $WITH_RADIUS == "yes" ]; then


### PR DESCRIPTION
Adding a `WITH_MONITORING` option to start prometheus and start getting metrics from `etcd` and `kafka`