### PR TITLE
Bumping up voltctl version and exporting path before HELM install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ curl -o $GOPATH/bin/kubectl -sSL https://storage.googleapis.com/kubernetes-relea
 curl -o $GOPATH/bin/kind \
 	-sSL https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-$(go env GOHOSTOS)-$(go env GOARCH)
 curl -o $GOPATH/bin/voltctl \
-	-sSL https://github.com/ciena/voltctl/releases/download/0.0.5-dev/voltctl-0.0.5_dev-$(go env GOHOSTOS)-$(go env GOARCH)
+	-sSL https://github.com/opencord/voltctl/releases/download/v1.0.12/voltctl-v1.0.12-$(go env GOHOSTOS)-$(go env GOARCH)
+export PATH=$(go env GOPATH)/bin:$PATH
 curl -sSL https://git.io/get_helm.sh | USE_SUDO=false HELM_INSTALL_DIR=$(go env GOPATH)/bin bash
 chmod 755 $GOPATH/bin/kind $GOPATH/bin/voltctl $GOPATH/bin/kubectl
 export PATH=$(go env GOPATH)/bin:$PATH


### PR DESCRIPTION
without the export of PATH before helm install I was getting
```
~/kind-voltha$ curl -sSL https://git.io/get_helm.sh | USE_SUDO=false HELM_INSTALL_DIR=$(go env GOPATH)/bin bash
Downloading https://get.helm.sh/helm-v2.16.3-linux-amd64.tar.gz
Preparing to install helm and tiller into /home/community/kind-voltha/bin
helm installed into /home/community/kind-voltha/bin/helm
tiller installed into /home/community/kind-voltha/bin/tiller
helm not found. Is /home/community/kind-voltha/bin on your $PATH?
Failed to install helm
	For support, go to https://github.com/helm/helm.
```