### PR TITLE
support new values for CONFIG_SADIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,55 +76,67 @@ source releases/voltha-2.2 && voltha up
 ```
 Please check the `releases` folder to see the available ones.
 
-| OPTION                                  | DEFAULT                           | DESCRIPTION                                                                         |
-| --------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------- |
-| `TYPE`                                  | minimal                           | `minimal` or `full` and determines number of cluster nodes and etcd cluster members |
-| `NAME`                                  | TYPE                              | Name of the KinD Cluster to be created                                              |
-| `DEPLOY_K8S`                            | yes                               | Should the KinD Kubernetes cluster be deployed?                                     |
-| `JUST_K8S`                              | no                                | Should just the KinD Kubernetes cluster be depoyed? (i.e. no VOLTHA)                |
-| `WITH_BBSIM`                            | no                                | Should the BBSIM POD be deployed?                                                   |
-| `NUM_OF_BBSIM`                          | 1                                 | number of BBSIM POD to start (minimum = 1, maximum = 10)                            |
-| `WITH_ONOS`                             | yes                               | Should `ONOS` service be deployed?                                                  |
-| `WITH_RADIUS`                           | no                                | Should `freeradius` service be deployed?                                            |
-| `WITH_EAPOL`                            | no                                | Configure the OLT app to push EAPOL flows                                           |
-| `WITH_DHCP`                             | no                                | Configure the OLT app to push DCHP flows                                            |
-| `WITH_IGMP`                             | no                                | Configure the OLT app to push IGMP flows                                            |
-| `WITH_TIMINGS`                          | no                                | Outputs duration of various steps of the install                                    |
-| `WITH_CHAOS`                            | no                                | Starts kube-monkey to introduce chaos                                               |
-| `WITH_ADAPTERS`                         | yes                               | Should device adpters be installed, if no overrides options for specific adapters   |
-| `WITH_SIM_ADAPTERS`                     | no                                | Should simulated device adapters be deployed (simulated adpaters deprecated)        |
-| `WITH_OPEN_ADAPTERS`                    | yes                               | Should open OLT and ONU adapters be deployed                                        |
-| `WITH_PORT_FORWARDS`                    | yes                               | Forwards ports for some services from localhost into the K8s cluster                |
-| `CONFIG_SADIS`                          | no                                | Configure SADIS entries into ONOS, if WITH_ONOS set to yes                          |
-| `SADIS_CFG`                             | onos-files/onos-sadis-sample.json | SADIS Configuration File to push, if CONFIG_SADIS set                               |
-| `INSTALL_ONOS_APPS`                     | no                                | Replaces/installs ONOS OAR files in onos-files/onos-apps                            |
-| `INSTALL_KUBECTL`                       | yes                               | Should a copy of `kubectl` be installed locally?                                    |
-| `INSTALL_HELM`                          | yes                               | Should a copy of `helm` be installed locallly?                                      |
-| `VOLTHA_LOG_LEVEL`                      | WARN                              | Log level to set for VOLTHA core processes                                          |
-| `ONOS_CHART`                            | onf/voltha                        | Helm chart to used to install ONOS                                                  |
-| `ONOS_CHART_VERSION`                    | latest                            | Version of helm chart for ONOS                                                      |
-| `VOLTHA_CHART`                          | onf/voltha                        | Helm chart to used to install voltha                                                |
-| `VOLTHA_CHART_VERSION`                  | latest                            | Version of Helm chart to install voltha                                             |
-| `VOLTHA_ADAPTER_SIM_CHART`              | onf/voltha-adapter-simulated      | Helm chart to use to install simulated device adapter                               |
-| `VOLTHA_ADAPTER_SIM_CHART_VERSION`      | latest                            | Version of Helm chart to install simulated device adapter                           |
-| `VOLTHA_BBSIM_CHART`                    | onf/bbsim                         | Helm chart to use to install bbsim                                                  |
-| `VOLTHA_BBSIM_CHART_VERSION`            | latest                            | Version of Helm chart to install bbim                                               |
-| `VOLTHA_ADAPTER_OPEN_OLT_CHART`         | onf/voltha-adapter-openolt        | Helm chart to use to install OpenOlt adapter                                        |
-| `VOLTHA_ADAPTER_OPEN_OLT_CHART_VERSION` | latest                            | Version of Helm chart to install OpenOlt adapter                                    |
-| `VOLTHA_ADAPTER_OPEN_ONU_CHART`         | onf/voltha-adapter-openonu        | Helm chart to use to install OpenOnu adapter                                        |
-| `VOLTHA_ADAPTER_OPEN_ONU_CHART_VERSION` | latest                            | Version of Helm chart to install OpenOnu adapter                                    |
-| `ONLY_ONE`                              | yes                               | Run a single `rw-core`, no `api-server`, and no `ssh` CLI                           |
-| `ENABLE_ONOS_EXTRANEOUS_RULES`          | no                                | Set ONOS to allows flow rules not set via ONOS                                      |
-| `UPDATE_HELM_REPOS`                     | yes                               | Update the Helm repository with the latest charts before installing                 |
-| `WAIT_ON_DOWN`                          | yes                               | When tearing down the VOLTHA, don't exit script until all containers are stoped     |
-| `KIND_VERSION`                          | v0.5.1                            | Version of KinD to install if using a KinD cluster                                  |
-| `VOLTCTL_VERSION`                       | latest                            | Version of `voltctl` to install or up/downgrade to and use                          |
-| `ONOS_API_PORT`                         | dynamic                           | (advanced) Override dynamic port selection for port forward for ONOS API            |
-| `ONOS_SSH_PORT`                         | dynamic                           | (advanced) Override dynamic port selection for port forward for ONOS SSH            |
-| `VOLTHA_API_PORT`                       | dynamic                           | (advanced) Override dynamic port selection for port forward for VOLTHA API          |
-| `VOLTHA_SSH_PORT`                       | dynamic                           | (advanced) Override dynamic port selection for port forward for VOLTHA SSH          |
-| `VOLTHA_ETCD_PORT`                      | dynamic                           | (advanced) Override dynamic port selection for port forward for VOLTHA etcd         |
-| `VOLTHA_KAFKA_PORT`                     | dynamic                           | (advanced) Override dynamic port selection for port forward for VOLTHA Kafka API    |
+| OPTION                                  | DEFAULT                                              | DESCRIPTION                                                                          |
+| --------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `TYPE`                                  | minimal                                              | `minimal` or `full` and determines number of cluster nodes and etcd cluster members  |
+| `NAME`                                  | TYPE                                                 | Name of the KinD Cluster to be created                                               |
+| `DEPLOY_K8S`                            | yes                                                  | Should the KinD Kubernetes cluster be deployed?                                      |
+| `JUST_K8S`                              | no                                                   | Should just the KinD Kubernetes cluster be depoyed? (i.e. no VOLTHA)                 |
+| `WITH_BBSIM`                            | no                                                   | Should the BBSIM POD be deployed?                                                    |
+| `NUM_OF_BBSIM`                          | 1                                                    | number of BBSIM POD to start (minimum = 1, maximum = 10)                             |
+| `WITH_ONOS`                             | yes                                                  | Should `ONOS` service be deployed?                                                   |
+| `WITH_RADIUS`                           | no                                                   | Should `freeradius` service be deployed?                                             |
+| `WITH_EAPOL`                            | no                                                   | Configure the OLT app to push EAPOL flows                                            |
+| `WITH_DHCP`                             | no                                                   | Configure the OLT app to push DCHP flows                                             |
+| `WITH_IGMP`                             | no                                                   | Configure the OLT app to push IGMP flows                                             |
+| `WITH_TIMINGS`                          | no                                                   | Outputs duration of various steps of the install                                     |
+| `WITH_CHAOS`                            | no                                                   | Starts kube-monkey to introduce chaos                                                |
+| `WITH_ADAPTERS`                         | yes                                                  | Should device adpters be installed, if no overrides options for specific adapters    |
+| `WITH_SIM_ADAPTERS`                     | no                                                   | Should simulated device adapters be deployed (simulated adpaters deprecated)         |
+| `WITH_OPEN_ADAPTERS`                    | yes                                                  | Should open OLT and ONU adapters be deployed                                         |
+| `WITH_PORT_FORWARDS`                    | yes                                                  | Forwards ports for some services from localhost into the K8s cluster                 |
+| `CONFIG_SADIS`                          | no                                                   | Configure SADIS entries into ONOS. Values: `yes`|`no`|`file`|`url`|`bbsim`           |
+| `SADIS_SUBSCRIBERS`                     | http://bbsim.voltha.svc:50074/v2/subscribers/%s      | URL for ONOS to use to query subsriber information if `CONFIG_SADIS` is set to `url` |
+| `SADIS_BANDWIDTH_PROFILES`              |http://bbsim.voltha.svc:50074/v2/bandwidthprofiles/%s | URL for ONOS to use to query bandwidth profiles if `CONFIG_SADIS` is set to `url`    |
+| `SADIS_CFG`                             | onos-files/onos-sadis-sample.json                    | SADIS Configuration File to push, if CONFIG_SADIS set                                |
+| `INSTALL_ONOS_APPS`                     | no                                                   | Replaces/installs ONOS OAR files in onos-files/onos-apps                             |
+| `INSTALL_KUBECTL`                       | yes                                                  | Should a copy of `kubectl` be installed locally?                                     |
+| `INSTALL_HELM`                          | yes                                                  | Should a copy of `helm` be installed locallly?                                       |
+| `VOLTHA_LOG_LEVEL`                      | WARN                                                 | Log level to set for VOLTHA core processes                                           |
+| `ONOS_CHART`                            | onf/voltha                                           | Helm chart to used to install ONOS                                                   |
+| `ONOS_CHART_VERSION`                    | latest                                               | Version of helm chart for ONOS                                                       |
+| `VOLTHA_CHART`                          | onf/voltha                                           | Helm chart to used to install voltha                                                 |
+| `VOLTHA_CHART_VERSION`                  | latest                                               | Version of Helm chart to install voltha                                              |
+| `VOLTHA_ADAPTER_SIM_CHART`              | onf/voltha-adapter-simulated                         | Helm chart to use to install simulated device adapter                                |
+| `VOLTHA_ADAPTER_SIM_CHART_VERSION`      | latest                                               | Version of Helm chart to install simulated device adapter                            |
+| `VOLTHA_BBSIM_CHART`                    | onf/bbsim                                            | Helm chart to use to install bbsim                                                   |
+| `VOLTHA_BBSIM_CHART_VERSION`            | latest                                               | Version of Helm chart to install bbim                                                |
+| `VOLTHA_ADAPTER_OPEN_OLT_CHART`         | onf/voltha-adapter-openolt                           | Helm chart to use to install OpenOlt adapter                                         |
+| `VOLTHA_ADAPTER_OPEN_OLT_CHART_VERSION` | latest                                               | Version of Helm chart to install OpenOlt adapter                                     |
+| `VOLTHA_ADAPTER_OPEN_ONU_CHART`         | onf/voltha-adapter-openonu                           | Helm chart to use to install OpenOnu adapter                                         |
+| `VOLTHA_ADAPTER_OPEN_ONU_CHART_VERSION` | latest                                               | Version of Helm chart to install OpenOnu adapter                                     |
+| `ONLY_ONE`                              | yes                                                  | Run a single `rw-core`, no `api-server`, and no `ssh` CLI                            |
+| `ENABLE_ONOS_EXTRANEOUS_RULES`          | no                                                   | Set ONOS to allows flow rules not set via ONOS                                       |
+| `UPDATE_HELM_REPOS`                     | yes                                                  | Update the Helm repository with the latest charts before installing                  |
+| `WAIT_ON_DOWN`                          | yes                                                  | When tearing down the VOLTHA, don't exit script until all containers are stoped      |
+| `KIND_VERSION`                          | v0.5.1                                               | Version of KinD to install if using a KinD cluster                                   |
+| `VOLTCTL_VERSION`                       | latest                                               | Version of `voltctl` to install or up/downgrade to and use                           |
+| `ONOS_API_PORT`                         | dynamic                                              | (advanced) Override dynamic port selection for port forward for ONOS API             |
+| `ONOS_SSH_PORT`                         | dynamic                                              | (advanced) Override dynamic port selection for port forward for ONOS SSH             |
+| `VOLTHA_API_PORT`                       | dynamic                                              | (advanced) Override dynamic port selection for port forward for VOLTHA API           |
+| `VOLTHA_SSH_PORT`                       | dynamic                                              | (advanced) Override dynamic port selection for port forward for VOLTHA SSH           |
+| `VOLTHA_ETCD_PORT`                      | dynamic                                              | (advanced) Override dynamic port selection for port forward for VOLTHA etcd          |
+| `VOLTHA_KAFKA_PORT`                     | dynamic                                              | (advanced) Override dynamic port selection for port forward for VOLTHA Kafka API     |
+
+### `CONFIG_SADIS` Values
+
+| VALUE            | DESCRIPTION     |
+| ---------------- | --------------- |
+| `yes` or `file`  | use the contents of a file to configure SADIS in ONOS. The file used defaults to<br>`onos-files/onos-sadis-sample.json` but can be specified via the `SADIS_CFG`<br>environment variable |
+| `no`             | do not configure ONOS for SADIS usage |
+| `url`            | configure ONOS to use SADIS via a URL. The URL used for subscriber information<br> is specified in the variable `SADIS_SUBSCRIBERS` and the URL used for bandwidth<br> profiles is specified in the variable `SADIS_BANDWIDTH_PROFILES` |
+| `bbsim`          | configure ONOS use use the SADIS servers that are part of BBSIM |
+
 
 ## GENERATED CONFIGURATION
 When the voltha script is run it generates a file that contains the

--- a/voltha
+++ b/voltha
@@ -82,7 +82,9 @@ WITH_SIM_ADAPTERS=${WITH_SIM_ADAPTERS:-no}
 WITH_OPEN_ADAPTERS=${WITH_OPEN_ADAPTERS:-yes}
 WITH_PORT_FORWARDS=${WITH_PORT_FORWARDS:-yes}
 ONLY_ONE=${ONLY_ONE:-yes}
-CONFIG_SADIS=${CONFIG_SADIS:-no}
+CONFIG_SADIS=${CONFIG_SADIS:-no} # yes | no | file | bbsim | URL
+SADIS_SUBSCRIBERS=${SADIS_SUBSCRIBERS:-http://bbsim.voltha.svc:50074/v2/subscribers/%s}
+SADIS_BANDWIDTH_PROFILES=${SADIS_BANDWIDTH_PROFILES:-http://bbsim.voltha.svc:50074/v2/bandwidthprofiles/%s}
 SADIS_CFG=${SADIS_CFG:-onos-files/onos-sadis-sample.json}
 INSTALL_ONOS_APPS=${INSTALL_ONOS_APPS:-no}
 JUST_K8S=${JUST_K8S:-no}
@@ -171,7 +173,6 @@ ALL_YES_NO="\
     WITH_SIM_ADAPTERS \
     WITH_OPEN_ADAPTERS \
     WITH_PORT_FORWARDS \
-    CONFIG_SADIS \
     JUST_K8S \
     DEPLOY_K8S \
     INSTALL_ONOS_APPS \
@@ -202,6 +203,7 @@ ALL_OPTIONS="\
     ONOS_CHART_VERSION \
     ONOS_API_PORT \
     ONOS_SSH_PORT \
+    CONFIG_SADIS \
     SADIS_CFG \
     VOLTHA_API_PORT \
     VOLTHA_SSH_PORT \
@@ -453,16 +455,19 @@ push_onos_config() {
     bspin - "$MSG $GEAR"
     while true; do
         if [ $TYPE == "file" ]; then
-          (set -x; curl --fail -sSL --user karaf:karaf -w "%{http_code}" -o $CMD_OUTPUT -X POST -H Content-Type:application/json http://$_ONOS_API_EP/onos/v1/$RESOURCE --data @$DATA >$SC_OUTPUT 2>/dev/null) >>$CMD_ECHO 2>&1
+            (set -x; curl --fail -sSL --user karaf:karaf -w "%{http_code}" -o $CMD_OUTPUT -X POST -H Content-Type:application/json http://$_ONOS_API_EP/onos/v1/$RESOURCE --data @$DATA >$SC_OUTPUT 2>/dev/null) >>$CMD_ECHO 2>&1
+            RESULT=$?
         fi
         if [ $TYPE == "json" ]; then
-          (set -x; curl --fail -sSL --user karaf:karaf -w "%{http_code}" -o $CMD_OUTPUT -X POST -H Content-Type:application/json http://$_ONOS_API_EP/onos/v1/$RESOURCE --data $DATA >$SC_OUTPUT 2>/dev/null) >>$CMD_ECHO 2>&1
+            (set -x; curl --fail -sSL --user karaf:karaf -w "%{http_code}" -o $CMD_OUTPUT -X POST -H Content-Type:application/json http://$_ONOS_API_EP/onos/v1/$RESOURCE --data $DATA >$SC_OUTPUT 2>/dev/null) >>$CMD_ECHO 2>&1
+            RESULT=$?
         fi
-        RESULT=$?
         # Dump everything to the log
         cat $CMD_ECHO >> $LOG
-        cat $CMD_OUTPUT >> $LOG
+        test -r $CMD_OUTPUT && cat $CMD_OUTPUT >> $LOG
         SC=$(cat $SC_OUTPUT)
+        echo "RESPONSE CODE: $SC" >> $LOG
+        echo "ERROR CODE: $RESULT" >> $LOG
 
         # clean up temp files
         rm -f $CMD_ECHO $CMD_OUTPUT $SC_OUTPUT
@@ -1219,11 +1224,67 @@ if [ $WITH_ONOS == "yes" ]; then
     if [ $ENABLE_ONOS_EXTRANEOUS_RULES == "yes" ]; then
         push_onos_config "file" "Enabling extraneous rules for ONOS" "configuration/org.onosproject.net.flow.impl.FlowRuleManager" "onos-files/olt-onos-enableExtraneousRules.json"
     fi
-    if [ -f onos-files/onos-sadis.json ]; then
-        push_onos_config "file" "[optional] Push ONOS SADIS Configuration" "network/configuration/apps/org.opencord.sadis" "onos-files/onos-sadis.json"
-    elif [ "$CONFIG_SADIS" == "yes" ]; then
+    if [ $(echo ":yes:file:" | grep -c ":$CONFIG_SADIS:") -eq 1 ]; then
         check_onos_app_active org.opencord.sadis
         push_onos_config "file" "[optional] Push ONOS SADIS Configuration: $SADIS_CFG" "network/configuration/apps/org.opencord.sadis" "$SADIS_CFG"
+    elif [ "$CONFIG_SADIS" == "bbsim" ]; then
+        push_onos_config "json" \
+            "[optional] Push ONOS configuration for BBSIM SADIS servers" \
+            "network/configuration/apps/org.opencord.sadis" \
+            "$(echo $(cat <<EOJ
+{
+    "sadis": {
+        "integration": {
+            "url": "http://bbsim.voltha.svc.cluster.local:50074/v2/subscribers/%s",
+            "cache": {
+                "enabled": true,
+                "maxsize": 50,
+                "ttl": "PT1m"
+            }
+        }
+    },
+    "bandwidthprofile": {
+        "integration": {
+            "url": "http://bbsim.voltha.svc.cluster.local:50074/v2/bandwidthprofiles/%s",
+            "cache": {
+                "enabled": true,
+                "maxsize": 50,
+                "ttl": "PT1m"
+            }
+        }
+    }
+}
+EOJ
+) | tr -d '[:space:]')"
+    elif [ "$CONFIG_SADIS" == "url" ]; then
+        push_onos_config "json" \
+            "[optional] Push ONOS configuration for custom SADIS and Bandwidth Profile servers" \
+            "network/configuration/apps/org.opencord.sadis" \
+            "$(echo $(cat <<EOJ
+{
+    "sadis": {
+        "integration": {
+            "url": "$SADIS_SUBSCRIBERS",
+            "cache": {
+                "enabled": true,
+                "maxsize": 50,
+                "ttl": "PT1m"
+            }
+        }
+    },
+    "bandwidthprofile": {
+        "integration": {
+            "url": "$SADIS_BANDWIDTH_PROFILES",
+            "cache": {
+                "enabled": true,
+                "maxsize": 50,
+                "ttl": "PT1m"
+            }
+        }
+    }
+}
+EOJ
+) | tr -d '[:space:]')"
     fi
 fi
 if [ "$WITH_TIMINGS" == "yes" ]; then
@@ -1385,11 +1446,23 @@ fi
 
 bspin "Create voltctl configuration file"
 (set -x; mkdir -p $HOME/.volt >>$LOG 2>&1) >>$LOG 2>&1
+MIN_VC_VERSION=$(echo -e "1.0.15\n$VC_VERSION" | sort -V | head -1)
 if [ $WITH_PORT_FORWARDS == "yes" ]; then
-    (set -x; voltctl -a v3 -k localhost:$VOLTHA_KAFKA_PORT -s localhost:$VOLTHA_API_PORT config > $HOME/.volt/config-$NAME 2>>$LOG) >>$LOG 2>&1
+    KAFKA_FLAG="-k localhost:$VOLTHA_KAFKA_PORT"
+    SERVER_FLAG="-s localhost:$VOLTHA_API_PORT"
+    ETCD_FLAG=
+    if [ "$MIN_VC_VERSION" == "1.0.15" ]; then
+        ETCD_FLAG="-e localhost:$VOLTHA_ETCD_PORT"
+    fi
 else
-    (set -x; voltctl -a v3 -k $(get_service_ep voltha voltha-kafka) -s $(get_service_ep voltha voltha-api) config > $HOME/.volt/config-$NAME 2>>$LOG) >>$LOG 2>&1
+    KAFKA_FLAG="-k $(get_service_ep voltha voltha-kafka)"
+    SERVER_FLAG="-s $(get_service_ep voltha voltha-api)"
+    ETCD_FLAG=
+    if [ "$MIN_VC_VERSION" == "1.0.15" ]; then
+        ETCD_FLAG="-e $(get_service_ep voltha voltha-etcd-client)"
+    fi
 fi
+(set -x; voltctl -a v3 $KAFKA_FLAG $SERVER_FLAG $ETCD_FLAG config > $HOME/.volt/config-$NAME 2>>$LOG) >>$LOG 2>&1
 espin $VERIFIED
 
 if [ ! -f "$NAME-env.sh" ]; then


### PR DESCRIPTION
yes|no operate as currently configured
file   operates like yes
bbsim  sets ONOS to use the BBSIM as a SADIS server
url    sets ONOS to use the URL defined in SADIS_SUBSCRIBERS for
       subscribers and SADIS_BANDWIDTH_PROFILES for bandwidth
       profiles

Also support the etcd endpoint reference for setting log level if a
version of voltctl is used that supports log level.