### PR TITLE
Correct voltha-onos version for 2.3 release

### DIFF
--- a/releases/voltha-2.3
+++ b/releases/voltha-2.3
@@ -10,4 +10,4 @@ export ONOS_CHART_VERSION=3.0.1
 # kind-voltha's default which is 'master'.
 # Also we need to specify the tag for voltha/voltha-onos image since this is
 # not in the ONOS chart.
-export EXTRA_HELM_FLAGS="--set defaults.image_tag=null,images.onos.tag=4.0.1 "
+export EXTRA_HELM_FLAGS="--set defaults.image_tag=null,images.onos.tag=4.0.2 "


### PR DESCRIPTION
The voltha-onos image needed for voltha 2.3 release is voltha-onos:4.0.2 not 4.0.1, addressing in the release file. 